### PR TITLE
feat: make graphql pretty

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@
 
 _Quickly scaffold a postman collection for a GraphQL API._
 
-GraphMan CLI generates an complete collection from a GraphQL endpoint, containing one request per query & mutation, with pre filled fields, parameters and variables.
+GraphMan CLI generates an complete collection from a GraphQL endpoint,
+containing one request per query & mutation, with pre filled fields, parameters
+and variables.
 
 _Note: GraphMan is designed for the postman-collection spec 2.1_
 
@@ -14,9 +16,10 @@ _Note: GraphMan is designed for the postman-collection spec 2.1_
 
 ## Motivation
 
-Visualizing and exploring existing graphql APIs can be quite daunting.
-Using postman to manage all your apis is pretty standard, however creating and maintaining collections is difficult.
-GraphMan makes thoses things easy, helping you for:
+Visualizing and exploring existing graphql APIs can be quite daunting. Using
+postman to manage all your apis is pretty standard, however creating and
+maintaining collections is difficult. GraphMan makes thoses things easy, helping
+you for:
 
 - Graph discovery
 - Graph testing
@@ -24,22 +27,27 @@ GraphMan makes thoses things easy, helping you for:
 
 ## Usage
 
-_GraphMan uses deno as a javascript / typescript runtime. That allows to run the CLI from the file url._
-To get started:
+_GraphMan uses deno as a javascript / typescript runtime. That allows to run the
+CLI from the file url._ To get started:
 
 - [Install deno](https://deno.land/#installation)
-- Run: `deno run https://raw.githubusercontent.com/Escape-Technologies/graphman/main/src/index.ts <graphql endpoint url>`
+- Run:
+  `deno run https://raw.githubusercontent.com/Escape-Technologies/graphman/main/src/index.ts <graphql endpoint url>`
 - Import the generated `[...].postman_collection.json` file in postman.
 
-However if you want to run the CLI locally, clone the repo and run: `deno run src/index.ts [url]`
+However if you want to run the CLI locally, clone the repo and run:
+`deno run src/index.ts [url]`
 
-_Note that deno will ask for network and file-system permissions as it's runtime is secure by default_
+_Note that deno will ask for network and file-system permissions as it's runtime
+is secure by default_
 
 ### Examples
 
-You can try graphman on public graphql APIs, and it is a great way to get started with graphQL:
+You can try graphman on public graphql APIs, and it is a great way to get
+started with graphQL:
 
-- Rick&Morty API: `deno run https://raw.githubusercontent.com/Escape-Technologies/graphman/main/src/index.ts https://rickandmortyapi.com/graphql`
+- Rick&Morty API:
+  `deno run https://raw.githubusercontent.com/Escape-Technologies/graphman/main/src/index.ts https://rickandmortyapi.com/graphql`
 
 | <img width="300" src="https://raw.githubusercontent.com/Escape-Technologies/graphman/main/collection-example.png"> |
 | :----------------------------------------------------------------------------------------------------------------: |
@@ -51,6 +59,7 @@ You can try graphman on public graphql APIs, and it is a great way to get starte
 
 ## Issues and contributions
 
-- Please open an issue if you encounter bugs, with reproduction steps and error message.
+- Please open an issue if you encounter bugs, with reproduction steps and error
+  message.
 - For feature requests, please open an issue too
 - Feel free to create merge requests to improve GraphMan !

--- a/README.md
+++ b/README.md
@@ -1,49 +1,56 @@
 # GraphMan
+
 <p align="center">
   <img width="300" src="https://raw.githubusercontent.com/Escape-Technologies/graphman/main/graphman.svg">
-</p> 
+</p>
 
-*Quikly scaffold a postman collection for a GraphQL API.* 
+_Quickly scaffold a postman collection for a GraphQL API._
 
-GraphMan CLI generates an complete collection from a GraphQL endpoint, containing one request per query & mutation, with pre filled fields, parameters and variables. 
+GraphMan CLI generates an complete collection from a GraphQL endpoint, containing one request per query & mutation, with pre filled fields, parameters and variables.
 
-*Note: GraphMan is designed for the postman-collection spec 2.1*
+_Note: GraphMan is designed for the postman-collection spec 2.1_
 
 ✨GraphMan is fully compatible with the Insomnia API Client out of the box!✨
 
 ## Motivation
-Visualizing and exploring existing graphql APIs can be quite daunting. 
+
+Visualizing and exploring existing graphql APIs can be quite daunting.
 Using postman to manage all your apis is pretty standard, however creating and maintaining collections is difficult.
 GraphMan makes thoses things easy, helping you for:
+
 - Graph discovery
 - Graph testing
 - Collection updating
 
 ## Usage
-*GraphMan uses deno as a javascript / typescript runtime. That allows to run the CLI from the file url.*
+
+_GraphMan uses deno as a javascript / typescript runtime. That allows to run the CLI from the file url._
 To get started:
+
 - [Install deno](https://deno.land/#installation)
 - Run: `deno run https://raw.githubusercontent.com/Escape-Technologies/graphman/main/src/index.ts <graphql endpoint url>`
 - Import the generated `[...].postman_collection.json` file in postman.
 
 However if you want to run the CLI locally, clone the repo and run: `deno run src/index.ts [url]`
 
-*Note that deno will ask for network and file-system permissions as it's runtime is secure by default*
+_Note that deno will ask for network and file-system permissions as it's runtime is secure by default_
 
 ### Examples
+
 You can try graphman on public graphql APIs, and it is a great way to get started with graphQL:
+
 - Rick&Morty API: `deno run https://raw.githubusercontent.com/Escape-Technologies/graphman/main/src/index.ts https://rickandmortyapi.com/graphql`
 
-|<img width="300" src="https://raw.githubusercontent.com/Escape-Technologies/graphman/main/collection-example.png">|
-|:--:| 
-| *GraphMan collection for the Rick and morty API* |
+| <img width="300" src="https://raw.githubusercontent.com/Escape-Technologies/graphman/main/collection-example.png"> |
+| :----------------------------------------------------------------------------------------------------------------: |
+|                                  _GraphMan collection for the Rick and morty API_                                  |
 
-|<img width="500" src="https://raw.githubusercontent.com/Escape-Technologies/graphman/main/query-example.png">|
-|:--:| 
-| *Character query for the Rick and morty API collection* |
+| <img width="500" src="https://raw.githubusercontent.com/Escape-Technologies/graphman/main/query-example.png"> |
+| :-----------------------------------------------------------------------------------------------------------: |
+|                            _Character query for the Rick and morty API collection_                            |
 
 ## Issues and contributions
+
 - Please open an issue if you encounter bugs, with reproduction steps and error message.
 - For feature requests, please open an issue too
 - Feel free to create merge requests to improve GraphMan !
-

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,30 +1,29 @@
-import {createPostmanCollection, saveJsonFormatted} from './lib.ts'
+import { createPostmanCollection, saveJsonFormatted } from "./lib.ts";
 
 function help() {
-	console.log(`Error: not enough arguments.
+  console.log(`Error: not enough arguments.
 Usage:
 	deno run index.ts [graphql endpoint url]
 `);
 }
 
-if(Deno.args.length < 1) {
-	help();
-	Deno.exit(1);
+if (Deno.args.length < 1) {
+  help();
+  Deno.exit(1);
 }
 
 const url = Deno.args[0];
 const urlRegexp = /https?:\/\/*/;
-if(!urlRegexp.test(url)) {
-	console.error(`${url} is not a valid url`);
-	Deno.exit(1);
+if (!urlRegexp.test(url)) {
+  console.error(`${url} is not a valid url`);
+  Deno.exit(1);
 }
 console.log(`Creating the postman collection for ${url}`);
 
 const collection = await createPostmanCollection(url);
 
-const outName = collection.info.name + '.postman_collection.json'
+const outName = collection.info.name + ".postman_collection.json";
 saveJsonFormatted(collection, outName);
 
 console.log(`Collection saved as ${outName}`);
 console.log(`Import it in postman and complete the queries ! 🚀`);
-

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -168,19 +168,19 @@ function fieldToItem(
   field.args.forEach((arg: any, index) => {
     const formatedArg = typeFormater.formatArgument(arg);
     queryVarsDefinition += `${index === 0 ? "" : ","}${
-      field.args.length > 3 ? "\n\t" : " "
+      field.args.length > 3 ? "\n" : " "
     }$${arg.name}: ${formatedArg.formatedType}`;
 
     fieldVars += `${index === 0 ? "" : ", "}${
-      field.args.length > 3 ? "\n\t\t" : " "
+      field.args.length > 3 ? "\n" : " "
     }${arg.name}: $${arg.name}`;
 
-    variables += `${index === 0 ? "" : ",\n"}\t${formatedArg.formatedVariable}`;
+    variables += `${index === 0 ? "" : ",\n"}${formatedArg.formatedVariable}`;
   });
 
   if (field.args.length > 3) {
     queryVarsDefinition += "\n";
-    fieldVars += "\n\t";
+    fieldVars += "\n";
   }
 
   let formatedFields = "__typename\n";
@@ -206,8 +206,8 @@ function fieldToItem(
   const parsed = graphql.parse(
     `${type} ${field.name}${
       hasArgs ? `(${queryVarsDefinition})` : ""
-    }{\n\t${field.name}${hasArgs ? `(${fieldVars})` : ""}${
-      hasFields ? `{\n${formatedFields}\t}` : ""
+    }{\n${field.name}${hasArgs ? `(${fieldVars})` : ""}${
+      hasFields ? `{\n${formatedFields}}` : ""
     }\n}`,
   )
   let itemQuery = graphql.print(
@@ -283,7 +283,7 @@ export async function createPostmanCollection(url: string) {
     item.push(postmanItem);
   });
 
-  const name = url.split("//")[1].split("/")[0] + "-autoGQL";
+  const name = url.split("//")[1].split("/")[0] + "-GraphMan";
   const collection: PostmanCollection = {
     info: {
       name,

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -47,7 +47,7 @@ function query(url: string, query: string) {
 
 function findType(
   typeName: string,
-  introspectionQuery: graphql.IntrospectionQuery
+  introspectionQuery: graphql.IntrospectionQuery,
 ): graphql.IntrospectionType | undefined {
   const types = introspectionQuery.__schema.types;
   return types.find((type) => type.name === typeName);
@@ -152,7 +152,7 @@ function fieldToItem(
   field: graphql.IntrospectionField,
   url: string,
   typeFormater: TypeFormater,
-  type: "query" | "mutation"
+  type: "query" | "mutation",
 ): PostmanItem {
   let queryVarsDefinition = "";
   let fieldVars = "";
@@ -177,14 +177,14 @@ function fieldToItem(
     fieldVars += "\n\t";
   }
 
-  let formatedFields = "";
+  let formatedFields = "__typename\n";
 
   // @TODO: remove any types
   const _field = field as any;
   const fieldBaseType = typeFormater.getBaseType(_field.type);
   const queryReturnedType = findType(
     fieldBaseType.name,
-    typeFormater.introspection
+    typeFormater.introspection,
   ) as graphql.IntrospectionObjectType;
 
   if (queryReturnedType.kind === "OBJECT") {
@@ -195,16 +195,16 @@ function fieldToItem(
   }
 
   const hasArgs = field.args.length > 0;
-  const hasFields =
-    queryReturnedType.kind === "OBJECT" && queryReturnedType.fields.length > 0;
+  const hasFields = queryReturnedType.kind === "OBJECT" &&
+    queryReturnedType.fields.length > 0;
   const itemQuery = graphql.print(
     graphql.parse(
-      `${type} ${field.name}${hasArgs ? `(${queryVarsDefinition})` : ""}{\n\t${
-        field.name
-      }${hasArgs ? `(${fieldVars})` : ""}${
+      `${type} ${field.name}${
+        hasArgs ? `(${queryVarsDefinition})` : ""
+      }{\n\t${field.name}${hasArgs ? `(${fieldVars})` : ""}${
         hasFields ? `{\n${formatedFields}\t}` : ""
-      }\n}`
-    )
+      }\n}`,
+    ),
   );
 
   const formattedVariables = `{\n${variables}\n}`;
@@ -246,12 +246,12 @@ export async function createPostmanCollection(url: string) {
   const introspectionQuery = introspection.data as graphql.IntrospectionQuery;
 
   const queryType = introspectionQuery.__schema.types.find(
-    (type) => type.name === "Query"
+    (type) => type.name === "Query",
   ) as graphql.IntrospectionObjectType;
   if (!queryType) throw new Error("Query type not found");
 
   const mutationType = introspectionQuery.__schema.types.find(
-    (type) => type.name === "Mutation"
+    (type) => type.name === "Mutation",
   ) as graphql.IntrospectionObjectType;
   if (!queryType) throw new Error("Mutation type not found");
 

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -47,7 +47,7 @@ function query(url: string, query: string) {
 
 function findType(
   typeName: string,
-  introspectionQuery: graphql.IntrospectionQuery,
+  introspectionQuery: graphql.IntrospectionQuery
 ): graphql.IntrospectionType | undefined {
   const types = introspectionQuery.__schema.types;
   return types.find((type) => type.name === typeName);
@@ -110,7 +110,8 @@ class TypeFormater {
   formatField(field: graphql.IntrospectionField): Field {
     let description = "\n";
     if (
-      field.description && field.description !== "undefined" &&
+      field.description &&
+      field.description !== "undefined" &&
       field.description !== ""
     ) {
       description = ` # ${field.description?.replace("\n", " ")}\n`;
@@ -151,7 +152,7 @@ function fieldToItem(
   field: graphql.IntrospectionField,
   url: string,
   typeFormater: TypeFormater,
-  type: "query" | "mutation",
+  type: "query" | "mutation"
 ): PostmanItem {
   let queryVarsDefinition = "";
   let fieldVars = "";
@@ -183,7 +184,7 @@ function fieldToItem(
   const fieldBaseType = typeFormater.getBaseType(_field.type);
   const queryReturnedType = findType(
     fieldBaseType.name,
-    typeFormater.introspection,
+    typeFormater.introspection
   ) as graphql.IntrospectionObjectType;
 
   if (queryReturnedType.kind === "OBJECT") {
@@ -194,13 +195,17 @@ function fieldToItem(
   }
 
   const hasArgs = field.args.length > 0;
-  const hasFields = queryReturnedType.kind === "OBJECT" &&
-    queryReturnedType.fields.length > 0;
-  const itemQuery = `${type}${
-    hasArgs ? `(${queryVarsDefinition})` : ""
-  }{\n\t${field.name}${hasArgs ? `(${fieldVars})` : ""}${
-    hasFields ? `{\n${formatedFields}\t}` : ""
-  }\n}`;
+  const hasFields =
+    queryReturnedType.kind === "OBJECT" && queryReturnedType.fields.length > 0;
+  const itemQuery = graphql.print(
+    graphql.parse(
+      `${type} ${field.name}${hasArgs ? `(${queryVarsDefinition})` : ""}{\n\t${
+        field.name
+      }${hasArgs ? `(${fieldVars})` : ""}${
+        hasFields ? `{\n${formatedFields}\t}` : ""
+      }\n}`
+    )
+  );
 
   const formattedVariables = `{\n${variables}\n}`;
 
@@ -241,12 +246,12 @@ export async function createPostmanCollection(url: string) {
   const introspectionQuery = introspection.data as graphql.IntrospectionQuery;
 
   const queryType = introspectionQuery.__schema.types.find(
-    (type) => type.name === "Query",
+    (type) => type.name === "Query"
   ) as graphql.IntrospectionObjectType;
   if (!queryType) throw new Error("Query type not found");
 
   const mutationType = introspectionQuery.__schema.types.find(
-    (type) => type.name === "Mutation",
+    (type) => type.name === "Mutation"
   ) as graphql.IntrospectionObjectType;
   if (!queryType) throw new Error("Mutation type not found");
 
@@ -273,6 +278,6 @@ export async function createPostmanCollection(url: string) {
     },
     item,
   };
-  
+
   return collection;
 }


### PR DESCRIPTION
I ran the final output through the `print`/`parse` functions of `graphql` to remove any unwanted spaces. This should mean we can simplify some of the formatting functions, and rely on this, as well as `JSON.stringify` later (for variables, etc.)

lmkwyt