### PR TITLE
Feat/change default output path and add format exceptions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.postman_collection.json
+/out

--- a/README.md
+++ b/README.md
@@ -34,16 +34,28 @@ you for:
 
 ## Usage
 
+### Run from url
 _GraphMan uses deno as a javascript / typescript runtime. That allows to run the
 CLI from the file url._ To get started:
 
-- [Install deno](https://deno.land/#installation)
-- Run:
+1. [Install deno](https://deno.land/#installation)
+2. Run:
   `deno run https://deno.land/x/graphman@v1.0.1/src/index.ts <graphql endpoint url>`
-- Import the generated `[...].postman_collection.json` file in postman.
+3. Import the generated `[...].postman_collection.json` file in postman.
 
-However if you want to run the CLI locally, clone the repo and run:
-`deno run src/index.ts [url]`
+### Install GraphMan
+If you want to access graphman easly you can "install" it on your machine:
+1. [Install deno](https://deno.land/#installation)
+2. Run: `deno install -r -f --allow-net --allow-write -n graphman https://deno.land/x/graphman/src/index.ts`
+3. The command will output `export PATH="..."` copy paste it in your `~/.bashrc` or `~/.zshrc` file to add graphman to your path.
+You can now run graphman using the `graphman <params>` command! 🎉
+To **update** GraphMan just reproduce the **step 2**.
+
+_Note: this is not a real installation, it just creates a script that basically aliases the run form url command._
+
+### Run locally
+1. Clone the repo
+2. Run `deno run src/index.ts <params>`
 
 _Note that deno will ask for network and file-system permissions as it's runtime
 is secure by default_

--- a/README.md
+++ b/README.md
@@ -35,25 +35,32 @@ you for:
 ## Usage
 
 ### Run from url
+
 _GraphMan uses deno as a javascript / typescript runtime. That allows to run the
 CLI from the file url._ To get started:
 
 1. [Install deno](https://deno.land/#installation)
 2. Run:
-  `deno run https://deno.land/x/graphman@v1.0.1/src/index.ts <graphql endpoint url>`
+   `deno run https://deno.land/x/graphman@v1.0.1/src/index.ts <graphql endpoint url>`
 3. Import the generated `[...].postman_collection.json` file in postman.
 
 ### Install GraphMan
-If you want to access graphman easly you can "install" it on your machine:
-1. [Install deno](https://deno.land/#installation)
-2. Run: `deno install -r -f --allow-net --allow-write -n graphman https://deno.land/x/graphman/src/index.ts`
-3. The command will output `export PATH="..."` copy paste it in your `~/.bashrc` or `~/.zshrc` file to add graphman to your path.
-You can now run graphman using the `graphman <params>` command! 🎉
-To **update** GraphMan just reproduce the **step 2**.
 
-_Note: this is not a real installation, it just creates a script that basically aliases the run form url command._
+If you want to access graphman easly you can "install" it on your machine:
+
+1. [Install deno](https://deno.land/#installation)
+2. Run:
+   `deno install -r -f --allow-net --allow-write -n graphman https://deno.land/x/graphman/src/index.ts`
+3. The command will output `export PATH="..."` copy paste it in your `~/.bashrc`
+   or `~/.zshrc` file to add graphman to your path. You can now run graphman
+   using the `graphman <params>` command! 🎉 To **update** GraphMan just
+   reproduce the **step 2**.
+
+_Note: this is not a real installation, it just creates a script that basically
+aliases the run form url command._
 
 ### Run locally
+
 1. Clone the repo
 2. Run `deno run src/index.ts <params>`
 

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -3,5 +3,10 @@
     // @TODO: Add this setting when tests are ready.
     // "ci": "deno fmt --check && deno lint && deno test -A --unstable"
     "ci": "deno fmt --check && deno lint"
+  },
+  "fmt": {
+    "files": {
+      "exclude": ["out"]
+    }
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,7 +24,7 @@ if (Deno.args.length < 1 || args.help || args.h) {
 }
 
 const url = args._[0];
-const filename = args.out;
+let path = args.out;
 const authorization = args.auth;
 
 const urlRegexp = /https?:\/\/*/;
@@ -36,8 +36,8 @@ console.log(`Creating the postman collection for ${url}`);
 
 const collection = await createPostmanCollection(url, authorization);
 
-const outName = filename || collection.info.name + ".postman_collection.json";
-saveJsonFormatted(collection, outName);
+path = path || "out/" + collection.info.name + ".postman_collection.json";
+saveJsonFormatted(collection, path);
 
-console.log(`Collection saved as ${outName}`);
+console.log(`Collection saved at ${path}`);
 console.log(`Import it in postman and complete the queries ! 🚀`);

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -57,8 +57,8 @@ function findType(
   return types.find((type) => type.name === typeName);
 }
 
-export function saveJsonFormatted(json: any, fileName: string) {
-  Deno.writeTextFileSync(fileName, JSON.stringify(json, null, "\t"));
+export function saveJsonFormatted(json: any, path: string) {
+  Deno.writeTextFileSync(path, JSON.stringify(json, null, "\t"));
 }
 interface Argument {
   formatedType: string;


### PR DESCRIPTION
## Description

Fixes #7 

Outputs are now defaulted to /out to prevent the root from being messy, and to ignore it while formating.
