### PR TITLE
feat: add queries and mutations folders to postman collection

### DIFF
--- a/src/format.ts
+++ b/src/format.ts
@@ -25,12 +25,17 @@ export interface PostmanItem {
   response: null[];
 }
 
+export interface PostmanFolder {
+  name: string;
+  item: PostmanItem[];
+}
+
 export interface PostmanCollection {
   info: {
     name: string;
     schema: string;
   };
-  item: PostmanItem[];
+  item: PostmanFolder[];
 }
 
 function queryToItem(
@@ -78,13 +83,15 @@ export function queryCollectionToPostmanCollection(
   url: string,
   authorization?: string,
 ) {
-  const item: PostmanItem[] = [];
+  const item: PostmanFolder[] = [];
+  item.push({ name: "Queries", item: [] });
   queryCollection.queries.forEach((query) => {
-    item.push(queryToItem(query, url, authorization));
+    item[0].item.push(queryToItem(query, url, authorization));
   });
   // @TODO: separate queries and mutations in folders
+  item.push({ name: "Mutations", item: [] });
   queryCollection.mutations.forEach((query) => {
-    item.push(queryToItem(query, url, authorization));
+    item[1].item.push(queryToItem(query, url, authorization));
   });
 
   const name = url.split("//")[1].split("/")[0] + "-GraphMan";


### PR DESCRIPTION
## Description

Fixes #30 

Queries and mutations are now separated in folders:
<img width="285" alt="image" src="https://user-images.githubusercontent.com/64989428/191916456-946d3fcc-71fa-484b-8a41-5bb05ff7b2b3.png">

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have ran `deno task ci` to ensure that my code is formatted and linted.
- [x] I have linked the related issue _(if there is no related issue please
      create one)_
- [ ] ~~I have added tests if applicable~~ (_needs tests to be ready_)
