### PR TITLE
feat: basic mock

### DIFF
--- a/src/converters.ts
+++ b/src/converters.ts
@@ -1,4 +1,5 @@
 import { parse, print } from "https://esm.sh/v90/graphql@16.5.0";
+import { generateMockData, getDefaultTypeValue, MockResponse } from "./mock.ts";
 import { Argument, ObjectField, Outrospection, Query } from "./outrospector.ts";
 
 export interface FormattedArgument {
@@ -18,31 +19,12 @@ export interface FormattedQuery {
   fullQuery: string;
   variables: string;
   outrospectQuery: Query;
+  mockResponse: MockResponse;
 }
 
 export interface QueryCollection {
   queries: FormattedQuery[];
   mutations: FormattedQuery[];
-}
-
-// @TODO: rework this
-function getDefaultValue(type: string) {
-  switch (type) {
-    case "ID":
-      return `"0"`;
-    case "STRING" || "String":
-      return `""`;
-    case "INT" || "Int":
-      return `0`;
-    case "FLOAT":
-      return `0.0`;
-    case "BOOLEAN":
-      return `false`;
-    case "INPUT_OBJECT":
-      return `{}`;
-    default:
-      return `null`;
-  }
 }
 
 function nestedArgToString(arg: Argument, argStr?: string): string {
@@ -64,7 +46,7 @@ function formatArgument(arg: Argument): FormattedArgument {
   const formattedType: string = nestedArgToString(arg);
 
   const defaultNonNullValue = formattedType
-    .replace(arg.typeName, getDefaultValue(arg.typeName))
+    .replace(arg.typeName, String(getDefaultTypeValue(arg.typeName)))
     .replaceAll("!", "");
   const defaultValue = formattedType.includes("!")
     ? defaultNonNullValue
@@ -152,6 +134,7 @@ function formatQuery(
     fullQuery: "",
     variables: "",
     outrospectQuery: query,
+    mockResponse: generateMockData(query, outrospection),
   };
 
   Array.from(query.args).forEach(([_, arg], index) => {

--- a/src/format.ts
+++ b/src/format.ts
@@ -28,6 +28,8 @@ interface PostmanResponse {
   header: null[];
   cookie: null[];
   _postman_previewlanguage: "json";
+  status: "OK";
+  code: 200;
 }
 export interface PostmanItem {
   name: string;
@@ -92,6 +94,8 @@ function queryToItem(
       header: [],
       cookie: [],
       _postman_previewlanguage: "json",
+      status: "OK",
+      code: 200,
     }],
   };
 

--- a/src/format.ts
+++ b/src/format.ts
@@ -1,5 +1,4 @@
 import { FormattedQuery, QueryCollection } from "./converters.ts";
-import { MockResponse } from "./mock.ts";
 
 interface PostmanRequest {
   method: string;

--- a/src/mock.ts
+++ b/src/mock.ts
@@ -1,0 +1,66 @@
+// The goal of this module is to generate fake data for types, for variables and mock responses
+
+import { Outrospection, Query } from "./outrospector.ts";
+
+const defaultValues = {
+  ID: "1",
+  String: "",
+  STRING: "",
+  Int: 0,
+  INT: 0,
+  Float: 0.0,
+  FLOAT: 0.0,
+  Boolean: false,
+  BOOLEAN: false,
+  INPUT_OBJECT: {},
+  OBJECT: {},
+};
+
+const defaultScalarValue = "1";
+
+export function getDefaultTypeValue(typeName: string) {
+  return Object(defaultValues)[typeName] ?? null;
+}
+
+export interface MockResponse {
+  data: {
+    // deno-lint-ignore no-explicit-any
+    [key: string]: any;
+  };
+}
+
+export function generateMockData(
+  query: Query,
+  outrospection: Outrospection,
+): MockResponse {
+  const mockData = new Map<string, string>();
+
+  const type = outrospection.types.get(query.typeName);
+  if (!type) {
+    throw new Error(`Type ${query.typeName} not found in outrospection`);
+  }
+
+  if (type.kind === "OBJECT") {
+    type.fields?.forEach((field) => {
+      mockData.set(field.name, getDefaultTypeValue(field.typeName));
+    });
+  } else if (type.kind === "SCALAR") {
+    mockData.set(type.name, defaultScalarValue);
+  } else {
+    //@TODO: handle other types if needed
+    mockData.set(
+      "notImplemented",
+      `Mock data for return type ${type.kind} is not implemented yet`,
+    );
+  }
+
+  const mock = {
+    data: {
+      [query.name]: {
+        "__typename": query.typeName,
+        ...Object.fromEntries(mockData),
+      },
+    },
+  };
+  return mock;
+}

--- a/src/outrospector.ts
+++ b/src/outrospector.ts
@@ -8,7 +8,7 @@ import {
 import { getQueryAndMutationTypes } from "./lib.ts";
 
 // @TODO add real support for "INTERFACE" | "UNION" | "INPUT_OBJECT"
-type TypeBaseKind =
+export type TypeBaseKind =
   | "LIST"
   | "NON_NULL"
   | "SCALAR"


### PR DESCRIPTION
## Description

Fixes #33 

Generates a basic response example for each query. Not perfect for now but useful however as it generates a base that can be manually extended by the users. Improvements will be made.

Stuck: example responses are ok in the collection, however, when generating a mock server with postman it doesn't pick up the correct example for the request. I believe that could be an issue on Postman side, will investigate in #33 before merging.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have ran `deno task ci` to ensure that my code is formatted and linted.
- [x] I have linked the related issue _(if there is no related issue please
      create one)_
- [ ] ~~I have added tests if applicable~~ (_needs tests to be ready_)
