### PR TITLE
feat: add description field to requests

### DIFF
--- a/src/format.ts
+++ b/src/format.ts
@@ -21,6 +21,7 @@ export interface PostmanItem {
       host: string[];
       path: string[];
     };
+    description: string | null;
   };
   response: null[];
 }
@@ -71,6 +72,7 @@ function queryToItem(
         host,
         path,
       },
+      description: query.outrospectQuery.description ?? null,
     },
     response: [],
   };


### PR DESCRIPTION
## Description

Fixes #31 

Adds a description in the generated collection for every request:
<img width="435" alt="image" src="https://user-images.githubusercontent.com/64989428/191973182-c59b360f-1050-4456-b26f-7e66d15030b3.png">


## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have ran `deno task ci` to ensure that my code is formatted and linted.
- [x] I have linked the related issue _(if there is no related issue please
      create one)_
- [ ] ~~I have added tests if applicable~~ (_needs tests to be ready_)
