### PR TITLE
Feat/interface and union types support

### DIFF
--- a/src/outrospector.ts
+++ b/src/outrospector.ts
@@ -74,6 +74,7 @@ function parseType(
   if (
     !(introspectionType.kind === "OBJECT" ||
       introspectionType.kind === "INTERFACE" ||
+      introspectionType.kind === "UNION" ||
       introspectionType.kind === "ENUM" ||
       introspectionType.kind === "SCALAR")
   ) {
@@ -88,11 +89,10 @@ function parseType(
     fields: undefined,
     description: introspectionType.description ?? undefined,
   };
-  if (type.kind === "INTERFACE") {
-    console.dir(type);
-  }
 
-  if (type.kind === "OBJECT" || type.kind === "INTERFACE") {
+  if (
+    type.kind === "OBJECT" || type.kind === "INTERFACE"
+  ) {
     type.fields = [];
     const introspectionObjectType =
       introspectionType as IntrospectionObjectType;

--- a/src/outrospector.ts
+++ b/src/outrospector.ts
@@ -88,8 +88,11 @@ function parseType(
     fields: undefined,
     description: introspectionType.description ?? undefined,
   };
+  if (type.kind === "INTERFACE") {
+    console.dir(type);
+  }
 
-  if (type.kind === "OBJECT") {
+  if (type.kind === "OBJECT" || type.kind === "INTERFACE") {
     type.fields = [];
     const introspectionObjectType =
       introspectionType as IntrospectionObjectType;

--- a/src/outrospector.ts
+++ b/src/outrospector.ts
@@ -73,6 +73,7 @@ function parseType(
 ): Type {
   if (
     !(introspectionType.kind === "OBJECT" ||
+      introspectionType.kind === "INTERFACE" ||
       introspectionType.kind === "ENUM" ||
       introspectionType.kind === "SCALAR")
   ) {
@@ -96,7 +97,7 @@ function parseType(
       const fieldType = field.type as IntrospectionType;
       type.fields?.push({
         name: field.name,
-        description: field.description ?? undefined,
+        description: field.description?.replaceAll("\n", " ") ?? undefined,
         typeName: fieldType.name,
         typeBaseKind: field.type.kind,
       });


### PR DESCRIPTION
## Description

Fixes #44 and #47 

Adds support for UNION and INTERFACE types. 
INTERFACE is treated as an OBJECT.
UNION support remains basic, it will not prefill the union with subtypes but is now accepted by the parser and present in the output as a commented type.
Better support could be done, but my bandwidth on this project is too thin now, and UNIONS don't seem to be used a lot.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have ran `deno task ci` to ensure that my code is formatted and linted.
- [x] I have linked the related issue _(if there is no related issue please
      create one)_
- [ ] ~~I have added tests if applicable~~ (_needs tests to be ready_)
